### PR TITLE
set encoding to UTF-8 for typetool.rb

### DIFF
--- a/lib/psd/layer_info/typetool.rb
+++ b/lib/psd/layer_info/typetool.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require_relative '../layer_info'
 
 class PSD


### PR DESCRIPTION
Fixes an error I was getting on ruby version 1.9.3: `invalid multibyte char (US-ASCII) (SyntaxError)`
