### PR TITLE
Fix 'undefined method' error encountered with layer masks

### DIFF
--- a/lib/psd/channel_image.rb
+++ b/lib/psd/channel_image.rb
@@ -66,7 +66,7 @@ class PSD
       end
 
       if @channel_data.length != @length
-        PSD.logger.error "#{channel_data.length} read; expected #{@length}"
+        PSD.logger.error "#{@channel_data.length} read; expected #{@length}"
       end
 
       process_image_data


### PR DESCRIPTION
This prevents errors such as these:

```
/Users/rsc/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/psd-1.1.1/lib/psd/channel_image.rb:69:in `parse': undefined local variable or method `channel_data' for #<PSD::ChannelImage:0x00000105710308> (NameError)
        from /Users/rsc/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/psd-1.1.1/lib/psd/layer.rb:101:in `parse_channel_image!'
        from /Users/rsc/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/psd-1.1.1/lib/psd/layer_mask.rb:59:in `block in parse'
        from /Users/rsc/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/psd-1.1.1/lib/psd/layer_mask.rb:57:in `each'
        from /Users/rsc/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/psd-1.1.1/lib/psd/layer_mask.rb:57:in `parse'
        from /Users/rsc/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/psd-1.1.1/lib/psd.rb:116:in `layer_mask'
        from /Users/rsc/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/psd-1.1.1/lib/psd.rb:75:in `parse!'
        from /Users/rsc/tmp/psd/lib/psdtool/document.rb:12:in `initialize'
        from psd.rb:5:in `new'
        from psd.rb:5:in `<main>'
```
