### PR TITLE
Active support 4.0 compatibility

### DIFF
--- a/psd.gemspec
+++ b/psd.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rake'
   gem.add_dependency 'psd-enginedata', '~> 1'
   gem.add_dependency 'chunky_png'
-  gem.add_dependency 'activesupport', '~> 4.0.0'
+  gem.add_dependency 'activesupport'
   gem.add_dependency 'xmp'
 
   gem.test_files = Dir.glob("spec/**/*")


### PR DESCRIPTION
Can't run PSD on rails 4.x with PSD depending on activesupport 3.2.7

removed dependency.

Reran tests with 3.2.7, 4.0.10, and 4.1.6 all fine.

Its not clear why the dependency was inserted in the first place
