### PR TITLE
Added support for text leading, and extended PSD support.

### DIFF
--- a/lib/psd/layer/info/typetool.rb
+++ b/lib/psd/layer/info/typetool.rb
@@ -53,6 +53,7 @@ class PSD
         sizes: sizes,
         colors: colors,
         alignment: alignment,
+        leadings: leadings,
         css: to_css
       }
     end
@@ -62,6 +63,12 @@ class PSD
     def fonts
       return [] if engine_data.nil?
       engine_data.ResourceDict.FontSet.map(&:Name)
+    end
+
+    # Return all leadings (line spacing) for this layer.
+    def leadings
+      return [] if engine_data.nil? || !styles.has_key?('Leading')
+      styles['Leading'].uniq
     end
 
     # Return all font sizes for this layer.

--- a/lib/psd/layer/info/typetool.rb
+++ b/lib/psd/layer/info/typetool.rb
@@ -50,6 +50,7 @@ class PSD
     def font
       {
         name: fonts.first,
+        fonts: fonts,
         sizes: sizes,
         colors: colors,
         alignment: alignment,

--- a/lib/psd/slice.rb
+++ b/lib/psd/slice.rb
@@ -3,7 +3,7 @@ class PSD
     attr_reader :id, :group_id, :origin, :associated_layer_id, :name, :type,
                 :bounds, :url, :target, :message, :alt, :cell_text_is_html,
                 :cell_text, :horizontal_alignment, :vertical_alignment,
-                :color
+                :color, :outset
 
     def initialize(psd, data)
       @psd = psd


### PR DESCRIPTION
The first commit simply fixes a bug that I encountered an error trying to load a PSD. It had a "output" attribute that wasn't correctly handled by `splice.rb`.

The second commit extends the `typetool.rb` functionality by also outputting Leading, which is essentially the line height of the text. I use this in a personal tool to convert the text in a document into CSS, and believe this functionality may be useful to others.