### PR TITLE
Fixed read_string bug

### DIFF
--- a/lib/psd/file.rb
+++ b/lib/psd/file.rb
@@ -71,7 +71,7 @@ class PSD
 
     # Reads a string of the given length and converts it to UTF-8 from the internally used MacRoman encoding.
     def read_string(length=nil)
-      length = @file.read(1).bytes.to_a[0] if length.nil?
+      length = read(1).bytes.to_a[0] if length.nil?
       read(length).delete("\000")
     end
 


### PR DESCRIPTION
When run without length, this causes an error: "undefined method 'read' for nil:NilClass"